### PR TITLE
To add link to AWS Greengrass ML connector for dependencies installation

### DIFF
--- a/accelerators/machine_learning_inference/Greengrass_Connectors.md
+++ b/accelerators/machine_learning_inference/Greengrass_Connectors.md
@@ -334,3 +334,5 @@ One of the cause could be the missing dependencies. For example, the log of the 
 ```
 
 To resolve the issue, install the dependency as required with command `$ sudo apt-get install -y libgfortran3`
+
+You might need other dependencies as described in the [AWS Greengrass ML Image Classification Connector](https://github.com/awsdocs/aws-greengrass-developer-guide/blob/master/doc_source/image-classification-connector.md#-python-37--2)


### PR DESCRIPTION
*Issue #, if available:* Dependencies required to run the MLI on Ubuntu, related issue: https://github.com/awslabs/aws-iot-greengrass-accelerators/issues/1

*Description of changes:*
We can help reducing the friction by including the document from the AWS Greengrass in the MLI setup.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
