### PR TITLE
[joysl] String replace needs a string attribute

### DIFF
--- a/v2/cdk-constructs/GreengrassV2Component/assets/create_component_version.py
+++ b/v2/cdk-constructs/GreengrassV2Component/assets/create_component_version.py
@@ -36,7 +36,7 @@ def replace(data, match, repl):
     elif isinstance(data, list):
         return [replace(i, match, repl) for i in data]
     else:
-        return data.replace(match, repl)
+        return str(data).replace(match, repl)
 
 
 def create_resources(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
While processing a JSON ggv2 recipe the component function will throw an error if the value of a JSON element is a number. Since replace method only applies to str

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
